### PR TITLE
Fix compiling in ruby 3.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-      - run: bundle exec rake compile
+      - run: bundle exec rake build
       - run: bundle exec rake spec
   lint:
     strategy:

--- a/tiktoken_ruby.gemspec
+++ b/tiktoken_ruby.gemspec
@@ -35,11 +35,7 @@ Gem::Specification.new do |spec|
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.extensions = ["ext/tiktoken_ruby/Cargo.toml"]
-
-  # Uncomment to register a new dependency of your gem
-  # spec.add_dependency "example-gem", "~> 1.0"
-  # spec.add_dependency "rb_sys", "~> 0.9"
+  spec.extensions = ["ext/tiktoken_ruby/extconf.rb"]
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html


### PR DESCRIPTION
Fixes #1 which highlighted that builds are failing in Ruby 3.0. I think this was because while this project started with rb_sys I'd briefly experimented with the native rust extension support available in Ruby 3.1+. While it worked I did end up switching back, but it looks like I never switched the gemspec file back. 