### PR TITLE
Move `rb_sys` gem dep to gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ gemspec
 gem "rake", "~> 13.0"
 
 gem "rake-compiler"
-gem "rb_sys"
 
 gem "rspec", "~> 3.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     tiktoken_ruby (0.0.4)
+      rb_sys (~> 0.9.68)
 
 GEM
   remote: https://rubygems.org/
@@ -64,13 +65,13 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  ruby
   x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES
   rake (~> 13.0)
   rake-compiler
-  rb_sys
   rspec (~> 3.0)
   standard (~> 1.3)
   tiktoken_ruby!

--- a/tiktoken_ruby.gemspec
+++ b/tiktoken_ruby.gemspec
@@ -37,6 +37,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.extensions = ["ext/tiktoken_ruby/extconf.rb"]
 
+  spec.add_dependency "rb_sys", "~> 0.9.68"
+
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html
 end


### PR DESCRIPTION
Rubygems can't see dependencies in Gemfiles. Like the [generated comment at the top of the Gemfile](https://github.com/IAPark/tiktoken_ruby/blob/daa47c7992653a2b08d1240e6123cf7c83c6aa0b/Gemfile#L5) suggests, gem dependencies intended to be exposed to users and automatically installed with the gem must be listed in the gemspec.

[Rubygems.org](https://rubygems.org/gems/tiktoken_ruby) shows no runtime dependencies for `tiktoken_ruby`:

![image](https://user-images.githubusercontent.com/94129/233200544-5018329a-4bef-414d-a8d0-d7b86d2d4a2e.png)

Compare to [another gem](https://rubygems.org/gems/classmate) with a Rust native extension:

<img width="681" alt="image" src="https://user-images.githubusercontent.com/94129/233200708-72fb36a5-c040-4e48-86b0-001ef17c71fa.png">

Fixes #1.