### PR TITLE
Update magnus for ruby-head compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ruby: [3.2, 3.0, 2.7]
+        ruby: ['ruby-head', '3.2', '3.0', '2.7']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,6 +400,7 @@ name = "tiktoken_ruby"
 version = "0.1.0"
 dependencies = [
  "magnus",
+ "rb-sys",
  "tiktoken-rs",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,11 +31,11 @@ checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "bindgen"
-version = "0.60.1"
+version = "0.66.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
+checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
 dependencies = [
- "bitflags",
+ "bitflags 2.4.0",
  "cexpr",
  "clang-sys",
  "lazy_static",
@@ -46,6 +46,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
+ "syn",
 ]
 
 [[package]]
@@ -68,6 +69,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "bstr"
@@ -163,20 +170,21 @@ dependencies = [
 
 [[package]]
 name = "magnus"
-version = "0.4.4"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc87660cd7daa49fddbfd524c836de54d5c927d520cd163f43700c5087c57d6c"
+checksum = "0516897a45f8ce8270a8910bcb94cd83538b19b6ae3a0c281a765df170b64695"
 dependencies = [
  "magnus-macros",
  "rb-sys",
  "rb-sys-env",
+ "seq-macro",
 ]
 
 [[package]]
 name = "magnus-macros"
-version = "0.3.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206cb23bfeea05180c97522ef6a3e52a4eb17b0ed2f30ee3ca9c4f994d2378ae"
+checksum = "5968c820e2960565f647819f5928a42d6e874551cab9d88d75e3e0660d7f71e3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -242,36 +250,36 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.52"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "rb-sys"
-version = "0.9.68"
+version = "0.9.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4783528e031c3902524cfe685e0008d644e8b34bad4d1a19c1f39f4394d0777b"
+checksum = "a57240b308b155b09dce81e32829966a99f52d1088b45957e4283e526c5317a1"
 dependencies = [
  "rb-sys-build",
 ]
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.68"
+version = "0.9.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c04474335dd597126d20fe90d94504b3582a30cbc36bc72c7d6ed3ef8cf168"
+checksum = "f24ce877a4c5d07f06f6aa6fec3ac95e4b357b9f73b0f5445d8cbb7266d410e8"
 dependencies = [
  "bindgen",
  "lazy_static",
@@ -294,7 +302,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -333,6 +341,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "seq-macro"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
+
+[[package]]
 name = "serde"
 version = "1.0.157"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -358,9 +372,9 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
+version = "2.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+checksum = "718fa2415bcb8d8bd775917a1bf12a7931b6dfa890753378538118181e0cb398"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/ext/tiktoken_ruby/Cargo.toml
+++ b/ext/tiktoken_ruby/Cargo.toml
@@ -10,5 +10,5 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-magnus = { version = "0.4" }
+magnus = { version = "0.6.1" }
 tiktoken-rs = { git = "https://github.com/IAPark/tiktoken-rs.git" }

--- a/ext/tiktoken_ruby/Cargo.toml
+++ b/ext/tiktoken_ruby/Cargo.toml
@@ -11,4 +11,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 magnus = { version = "0.6.1" }
+rb-sys = { version = "*", features = ["stable-api-compiled-fallback"] }
 tiktoken-rs = { git = "https://github.com/IAPark/tiktoken-rs.git" }


### PR DESCRIPTION
Older versions of magnus fail to compile on Ruby 3.3.0-dev with:

```
Compiling tiktoken-rs v0.3.2
(https://github.com/IAPark/tiktoken-rs.git#5231fbf4)
error[E0609]: no field `len` on type `RString__bindgen_ty_1__bindgen_ty_1`
-->
/tmp/bundle/ruby/3.3.0+0/gems/tiktoken_ruby-0.0.5/ext/tiktoken_ruby/.rb-sys/stable/cargo/registry/src/index.crates.io-6f17d22bba15001f/magnus-0.4.4/src/r_string.rs:366:57
    |
366 |             slice::from_raw_parts(h.ptr as *const u8, h.len as usize)
    |                                                         ^^^ unknown field
    |
    = note: available fields are: `ptr`, `aux`
error[E0609]: no field `len` on type `RString__bindgen_ty_1__bindgen_ty_1`
-->
/tmp/bundle/ruby/3.3.0+0/gems/tiktoken_ruby-0.0.5/ext/tiktoken_ruby/.rb-sys/stable/cargo/registry/src/index.crates.io-6f17d22bba15001f/magnus-0.4.4/src/r_string.rs:954:19
    |
954 |                 h.len as usize
    |                   ^^^ unknown field
    |
    = note: available fields are: `ptr`, `aux`
error[E0609]: no field `len` on type `RString__bindgen_ty_1__bindgen_ty_2`
-->
/tmp/bundle/ruby/3.3.0+0/gems/tiktoken_ruby-0.0.5/ext/tiktoken_ruby/.rb-sys/stable/cargo/registry/src/index.crates.io-6f17d22bba15001f/magnus-0.4.4/src/r_string.rs:996:44
    |
996 |     value.as_internal().as_ref().as_.embed.len
    |                                            ^^^ unknown field
    |
    = note: available fields are: `ary`
For more information about this error, try `rustc --explain E0609`.
error: could not compile `magnus` (lib) due to 3 previous errors
warning: build failed, waiting for other jobs to finish...
make: *** [Makefile:564: target/release/libtiktoken_ruby.so] Error 101
```

cc @IAPark 