### PR TITLE
Enhance extconf.rb for Cross-Platform Compatibility

### DIFF
--- a/ext/tiktoken_ruby/extconf.rb
+++ b/ext/tiktoken_ruby/extconf.rb
@@ -1,6 +1,27 @@
 # frozen_string_literal: true
 
-require "mkmf"
-require "rb_sys/mkmf"
+require 'mkmf'
+require 'rb_sys/mkmf'
 
-create_rust_makefile("tiktoken_ruby/tiktoken_ruby")
+# Detect the operating system
+os = RbConfig::CONFIG['host_os']
+
+# Custom configurations for OpenBSD and FreeBSD
+if os.include?('openbsd') || os.include?('freebsd')
+  $CFLAGS << ' -I/usr/local/include'  # Include path for headers
+  ENV['RUSTFLAGS'] = '-C link-arg=-lpthread'  # Link with pthread
+end
+
+# Custom configurations for Linux
+if os.include?('linux')
+  $CFLAGS << ' -O2 -Wall'  # Optimization and warnings
+  ENV['RUSTFLAGS'] = '-C target-cpu=native'  # CPU-specific optimizations
+end
+
+# Custom configurations for macOS (Darwin)
+if os.include?('darwin')
+  $CFLAGS << ' -O2 -Wall'  # Example C flags
+end
+
+# Generate the Makefile
+create_rust_makefile('tiktoken_ruby/tiktoken_ruby')


### PR DESCRIPTION
Update the extconf.rb file to automatically detect and set appropriate compiler flags for OpenBSD/FreeBSD, Linux, and macOS environments. This enhancement ensures that the tiktoken_ruby gem can be built reliably across different operating systems by customizing the build process according to the detected OS.