### PR TITLE
Upgrade dependencies including `rb_sys` to 0.9.86 for Ruby 3.3.0 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,15 +2,11 @@
 
 source "https://rubygems.org"
 
-# Specify your gem's dependencies in tiktoken_ruby.gemspec
 gemspec
 
-gem "rake", "~> 13.0"
-
+gem "rake"
 gem "rake-compiler"
-
-gem "rspec", "~> 3.0"
-
-gem "standard", "~> 1.3"
-
-gem "yard-doctest", "~> 0.1.17"
+gem "rspec"
+gem "standard"
+gem "yard-doctest"
+gem "racc"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,63 +2,73 @@ PATH
   remote: .
   specs:
     tiktoken_ruby (0.0.6)
-      rb_sys (~> 0.9.68)
+      rb_sys (>= 0.9.86)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
     diff-lcs (1.5.0)
-    json (2.6.3)
+    json (2.7.1)
     language_server-protocol (3.17.0.3)
-    minitest (5.18.0)
-    parallel (1.22.1)
-    parser (3.2.1.1)
+    lint_roller (1.1.0)
+    minitest (5.21.2)
+    parallel (1.24.0)
+    parser (3.3.0.4)
       ast (~> 2.4.1)
+      racc
+    racc (1.7.3)
     rainbow (3.1.1)
-    rake (13.0.6)
-    rake-compiler (1.2.1)
+    rake (13.1.0)
+    rake-compiler (1.2.5)
       rake
-    rb_sys (0.9.68)
-    regexp_parser (2.7.0)
-    rexml (3.2.5)
+    rb_sys (0.9.86)
+    regexp_parser (2.9.0)
+    rexml (3.2.6)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
       rspec-mocks (~> 3.12.0)
-    rspec-core (3.12.1)
+    rspec-core (3.12.2)
       rspec-support (~> 3.12.0)
-    rspec-expectations (3.12.2)
+    rspec-expectations (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.4)
+    rspec-mocks (3.12.6)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-support (3.12.0)
-    rubocop (1.48.1)
+    rspec-support (3.12.1)
+    rubocop (1.59.0)
       json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
-      parser (>= 3.2.0.0)
+      parser (>= 3.2.2.4)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.26.0, < 2.0)
+      rubocop-ast (>= 1.30.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.27.0)
+    rubocop-ast (1.30.0)
       parser (>= 3.2.1.0)
-    rubocop-performance (1.16.0)
-      rubocop (>= 1.7.0, < 2.0)
-      rubocop-ast (>= 0.4.0)
+    rubocop-performance (1.20.2)
+      rubocop (>= 1.48.1, < 2.0)
+      rubocop-ast (>= 1.30.0, < 2.0)
     ruby-progressbar (1.13.0)
-    standard (1.25.1)
+    standard (1.33.0)
       language_server-protocol (~> 3.17.0.2)
-      rubocop (= 1.48.1)
-      rubocop-performance (= 1.16.0)
-    unicode-display_width (2.4.2)
-    webrick (1.7.0)
-    yard (0.9.28)
-      webrick (~> 1.7.0)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.59.0)
+      standard-custom (~> 1.0.0)
+      standard-performance (~> 1.3)
+    standard-custom (1.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.50)
+    standard-performance (1.3.1)
+      lint_roller (~> 1.1)
+      rubocop-performance (~> 1.20.2)
+    unicode-display_width (2.5.0)
+    yard (0.9.34)
     yard-doctest (0.1.17)
       minitest
       yard
@@ -70,12 +80,13 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  rake (~> 13.0)
+  racc
+  rake
   rake-compiler
-  rspec (~> 3.0)
-  standard (~> 1.3)
+  rspec
+  standard
   tiktoken_ruby!
-  yard-doctest (~> 0.1.17)
+  yard-doctest
 
 BUNDLED WITH
    2.4.6

--- a/tiktoken_ruby.gemspec
+++ b/tiktoken_ruby.gemspec
@@ -7,12 +7,10 @@ Gem::Specification.new do |spec|
   spec.version = Tiktoken::VERSION
   spec.authors = ["IAPark"]
   spec.email = ["isaac.a.park@gmail.com"]
-
   spec.summary = "Ruby wrapper for Tiktoken"
   spec.description = "An unofficial Ruby wrapper for Tiktoken, " \
     "a BPE tokenizer written by and used by OpenAI. It can be used to " \
     "count the number of tokens in text before sending it to OpenAI APIs."
-
   spec.homepage = "https://github.com/IAPark/tiktoken_ruby"
   spec.license = "MIT"
   spec.required_ruby_version = ">= 2.7.0"
@@ -22,11 +20,6 @@ Gem::Specification.new do |spec|
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/IAPark/tiktoken_ruby"
   spec.metadata["documentation_uri"] = "https://rubydoc.info/github/IAPark/tiktoken_ruby/main"
-
-  # spec.metadata["changelog_uri"] = "TODO: Put your gem's CHANGELOG.md URL here."
-
-  # Specify which files should be added to the gem when it is released.
-  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files = Dir.chdir(__dir__) do
     `git ls-files -z`.split("\x0").reject do |f|
       (f == __FILE__) || f.match(%r{\A(?:(?:bin|test|spec|features)/|\.(?:git|circleci)|appveyor)})
@@ -36,9 +29,5 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
   spec.extensions = ["ext/tiktoken_ruby/extconf.rb"]
-
-  spec.add_dependency "rb_sys", "~> 0.9.68"
-
-  # For more information and examples about making a new gem, check out our
-  # guide at: https://bundler.io/guides/creating_gem.html
+  spec.add_dependency "rb_sys", ">= 0.9.86"
 end


### PR DESCRIPTION
Also add `racc` as a development dependency as it's required when running `rake`.