### PR TITLE
Fix encoding_for_model to return nil for unknown encoding

### DIFF
--- a/lib/tiktoken_ruby.rb
+++ b/lib/tiktoken_ruby.rb
@@ -37,10 +37,13 @@ module Tiktoken
         return get_encoding(MODEL_TO_ENCODING_NAME[model_name.to_sym])
       end
 
-      _prefix, encoding = MODEL_PREFIX_TO_ENCODING.find do |prefix,_encoding|
+      _prefix, encoding = MODEL_PREFIX_TO_ENCODING.find do |prefix, _encoding|
         model_name.start_with?(prefix.to_s)
       end
-      encoding && get_encoding(encoding)
+
+      if encoding
+        get_encoding(encoding)
+      end
     end
 
     # Lists all the encodings that are supported

--- a/lib/tiktoken_ruby.rb
+++ b/lib/tiktoken_ruby.rb
@@ -28,7 +28,7 @@ module Tiktoken
 
     # Gets the encoding for an OpenAI model
     # @param model_name [Symbol|String] The name of the model to get the encoding for
-    # @return [Tiktoken::Encoding] The encoding instance
+    # @return [Tiktoken::Encoding, nil] The encoding instance, or nil if no encoding is found
     # @example Count tokens for text
     #   enc = Tiktoken.encoding_for_model("gpt-4")
     #   enc.encode("hello world").length #=> 2
@@ -37,11 +37,10 @@ module Tiktoken
         return get_encoding(MODEL_TO_ENCODING_NAME[model_name.to_sym])
       end
 
-      MODEL_PREFIX_TO_ENCODING.each do |prefix, encoding|
-        if model_name.start_with?(prefix.to_s)
-          return get_encoding(encoding)
-        end
+      _prefix, encoding = MODEL_PREFIX_TO_ENCODING.find do |prefix,_encoding|
+        model_name.start_with?(prefix.to_s)
       end
+      encoding && get_encoding(encoding)
     end
 
     # Lists all the encodings that are supported

--- a/spec/tiktoken_ruby_spec.rb
+++ b/spec/tiktoken_ruby_spec.rb
@@ -17,6 +17,10 @@ RSpec.describe Tiktoken do
     expect(Tiktoken.encoding_for_model("ft:gpt-3.5-turbo:org:suffix:abc123")).to be_a(Tiktoken::Encoding)
   end
 
+  it "fails gracefully when getting an encoding for an unknown model" do
+    expect(Tiktoken.encoding_for_model("bad-model-name")).to be_nil
+  end
+
   it "lists available encodings" do
     expect(Tiktoken.list_encoding_names).to be_a(Array)
   end


### PR DESCRIPTION
This pull request addresses issue #28.

Currently, when you pass an unrecognized model name to `Tiktoken.encoding_for_model`, instead of returning nil it returns an unexpected Hash, making it more difficult to detect whether the encoding is available. This seems to have been introduced by 0c1a45b46a

Added a simple spec to confirm.