### PR TITLE
Add a warning that get_encoding is not thread safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Encode and decode text
 ```ruby
 require 'tiktoken_ruby'
 
+# note: retrieving an encoding is not currently thread safe until https://github.com/IAPark/tiktoken_ruby/pull/30 is merged
 enc = Tiktoken.get_encoding("cl100k_base")
 enc.decode(enc.encode("hello world")) #=> "hello world"
 ```


### PR DESCRIPTION
This is following a suggestion from here https://github.com/IAPark/tiktoken_ruby/issues/8#issuecomment-2016434827 