### PR TITLE
[untested] Add gpt-4o support (o200k_base)

### DIFF
--- a/ext/tiktoken_ruby/src/lib.rs
+++ b/ext/tiktoken_ruby/src/lib.rs
@@ -19,6 +19,10 @@ fn cl100k_base() -> CoreBPEWrapper {
     let core_bpe = tiktoken_rs::cl100k_base().unwrap();
     CoreBPEWrapper::new(core_bpe)
 }
+fn o200k_base() -> CoreBPEWrapper {
+    let core_bpe = tiktoken_rs::o200k_base().unwrap();
+    CoreBPEWrapper::new(core_bpe)
+}
 
 fn module() -> Result<RModule, magnus::Error> {
     define_module("Tiktoken")
@@ -37,6 +41,7 @@ fn init() -> Result<(), Error> {
     factory_module.define_singleton_method("p50k_base", function!(p50k_base, 0))?;
     factory_module.define_singleton_method("p50k_edit", function!(p50k_edit, 0))?;
     factory_module.define_singleton_method("cl100k_base", function!(cl100k_base, 0))?;
+    factory_module.define_singleton_method("o200k_base", function!(o200k_base, 0))?;
 
     let ext_module = module.define_module("Ext")?;
     let bpe_class = ext_module.define_class("CoreBPE", class::object())?;

--- a/lib/tiktoken_ruby.rb
+++ b/lib/tiktoken_ruby.rb
@@ -71,6 +71,7 @@ module Tiktoken
     # that is also MIT licensed but by OpenAI
     MODEL_TO_ENCODING_NAME = {
       # chat
+      "gpt-4o": "o200k_base",
       "gpt-4": "cl100k_base",
       "gpt-3.5-turbo": "cl100k_base",
       "gpt-35-turbo": "cl100k_base",  # Azure deployment name
@@ -120,6 +121,7 @@ module Tiktoken
 
     MODEL_PREFIX_TO_ENCODING = {
       # chat
+      "gpt-4o-": "o200k_base",  # e.g., gpt-4o-2024-05-13, Added for gpt-4o model
       "gpt-4-": "cl100k_base",  # e.g., gpt-4-0314, etc., plus gpt-4-32k
       "gpt-3.5-turbo-": "cl100k_base",  # e.g, gpt-3.5-turbo-0301, -0401, etc.
       "gpt-35-turbo-": "cl100k_base",  # Azure deployment name


### PR DESCRIPTION
GPT-4o uses o200k_base which this gem currently does not support.

I tried adding it by looking at the Python library. I have NOT tested this code. I'm unfamiliar with Rust and wasn't able to compile it.

Just putting this PR out here to hopefully get the ball rolling on supporting this.