### PR TITLE
Add support for `chatgpt-4o-latest`

### DIFF
--- a/lib/tiktoken_ruby.rb
+++ b/lib/tiktoken_ruby.rb
@@ -69,9 +69,12 @@ module Tiktoken
     ]
 
     # taken from the python library here https://github.com/openai/tiktoken/blob/main/tiktoken/model.py
-    # that is also MIT licensed but by OpenAI
+    # that is also MIT licensed but by OpenAI;
+    # https://github.com/Congyuwang/tiktoken-rs/blob/main/tiktoken-rs/src/tokenizer.rs#L50
+    # is the source of the mapping for the Rust library
     MODEL_TO_ENCODING_NAME = {
       # chat
+      "chatgpt-4o-latest": "o200k_base",
       "gpt-4o": "o200k_base",
       "gpt-4": "cl100k_base",
       "gpt-3.5-turbo": "cl100k_base",

--- a/script/release
+++ b/script/release
@@ -7,24 +7,34 @@ if [ -z "${TIKTOKEN_PUBLISH_KEY}" ]; then
   exit 1
 fi
 
-version=$(grep VERSION lib/tiktoken_ruby/version.rb  | head -n 1 | cut -d'"' -f2)
-echo "Building tiktoken_ruby v$version"
-
-targets=(
-  "arm64-darwin"
-  "x86_64-darwin"
-  "aarch64-linux"
-  "x86_64-linux"
-  "x86_64-linux-musl"
-  "arm-linux"
-  "x64-mingw-ucrt"
-)
-
-for target in "${targets[@]}"; do
-  bundle exec rb-sys-dock -p "$target" --ruby-versions 3.2 --build
+run_id=""
+# Parse arguments
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+    --run-id)
+      run_id="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown parameter passed: $1"
+      exit 1
+      ;;
+  esac
 done
 
-for gem in pkg/tiktoken_ruby-"$version"*.gem ; do
+if [ -z "${run_id}" ]; then
+  echo "Error: --run-id is not provided. Please provide the GitHub Action run id for the cross-compile workflow."
+  exit 1
+fi
+
+version=$(grep VERSION lib/tiktoken_ruby/version.rb  | head -n 1 | cut -d'"' -f2)
+echo "Building tiktoken_ruby v$version, using artifacts from run $run_id"
+
+rm -rf pkg/cross-compiled
+gh run download "$run_id" -D pkg/cross-compiled
+
+for gem in pkg/cross-compiled/cross-gem-*/tiktoken_ruby-"$version"*.gem ; do
+  echo "Publishing $gem"
   GEM_HOST_API_KEY="${TIKTOKEN_PUBLISH_KEY}" gem push "$gem" --host https://rubygems.org
 done
 


### PR DESCRIPTION
https://github.com/zurawiki/tiktoken-rs/pull/85 added a catch-all `chatgpt-4o-latest` model -> tokenizer mapping, so it should probably be added here too. 

More importantly, this PR also updates the rb-sys build dependency, so issues like https://github.com/IAPark/tiktoken_ruby/issues/32 and https://github.com/IAPark/tiktoken_ruby/issues/34 should be resolved.

Lastly, after talking to @IAPark, I realized it would be easier to just publish the gems generated by the `cross-compile` GitHub Action; so I've updated `script/release` to just accept a run ID:

```
TIKTOKEN_PUBLISH_KEY=rubygems_... script/release --run-id 1234
```

That should minimize (if not outright eliminate) build discrepancies .