### PR TITLE
Lock rb-sys to 0.9.106

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,18 +265,18 @@ dependencies = [
 
 [[package]]
 name = "rb-sys"
-version = "0.9.105"
+version = "0.9.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b3a1f3ce8e7c36d777d52fe7a99039fe4fea7c8ec355a4c4f3a17f92a14029f"
+checksum = "17b6efdbc8c1a22cb8b5d7ead0237c16c362c9ef6fbdc09e2d1040615b0f4cd0"
 dependencies = [
  "rb-sys-build",
 ]
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.105"
+version = "0.9.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e6b246c29c0809e1cbe60a1ba9e093da72a4676d02adc68469297d1e589bbf0"
+checksum = "e1d88c51e52f8636a5efc24ec5987056e64e48a91ed2a1af96cb5564686cc10f"
 dependencies = [
  "bindgen",
  "lazy_static",

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    tiktoken_ruby (0.0.10)
-      rb_sys (>= 0.9.87)
+    tiktoken_ruby (0.0.11)
+      rb_sys (= 0.9.106)
 
 GEM
   remote: https://rubygems.org/
@@ -22,7 +22,7 @@ GEM
     rake (13.2.1)
     rake-compiler (1.2.9)
       rake
-    rb_sys (0.9.105)
+    rb_sys (0.9.106)
     regexp_parser (2.10.0)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)

--- a/ext/tiktoken_ruby/Cargo.toml
+++ b/ext/tiktoken_ruby/Cargo.toml
@@ -11,5 +11,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 magnus = { version = "0.7.1" }
-rb-sys = { version = "0.9.87", features = ["stable-api-compiled-fallback"] }
+rb-sys = { version = "0.9.106", features = ["stable-api-compiled-fallback"] }
 tiktoken-rs = { version = "0.6.0" }

--- a/tiktoken_ruby.gemspec
+++ b/tiktoken_ruby.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
   spec.extensions = ["ext/tiktoken_ruby/extconf.rb"]
-  spec.add_dependency "rb_sys", ">= 0.9.87"
+  spec.add_dependency "rb_sys", "0.9.106"
 end


### PR DESCRIPTION
For an inexplicable reason, the cross-compile action [passed in a PR](https://github.com/IAPark/tiktoken_ruby/actions/runs/12673864379) but failed when that [PR was merged into `main`](https://github.com/IAPark/tiktoken_ruby/actions/runs/12674055481).

Digging into it, one thing caught my eye:

 ```
 Installing rb_sys@0.9.87
Successfully installed rb_sys-0.9.87
1 gem installed
...
::info::🐳 Building for Ruby requested versions: ["3.1.0", "3.2.0", "3.3.0", "3.4.0"]
::info::🐳 Downloading container "rbsys/x86_64-linux:0.9.105", this might take awhile...
```

The rb_sys gem and rbsys docker image should always be matching. 0.9.106 contains a necessary fix for Rubies > 3.2, so it might as well point to that. 