### PR TITLE
Support gpt-4.1 encoding

### DIFF
--- a/lib/tiktoken_ruby.rb
+++ b/lib/tiktoken_ruby.rb
@@ -74,6 +74,7 @@ module Tiktoken
     # is the source of the mapping for the Rust library
     MODEL_TO_ENCODING_NAME = {
       # chat
+      "gpt-4.1": "o200k_base",
       "chatgpt-4o-latest": "o200k_base",
       "gpt-4o": "o200k_base",
       "gpt-4": "cl100k_base",
@@ -125,6 +126,7 @@ module Tiktoken
 
     MODEL_PREFIX_TO_ENCODING = {
       # chat
+      "gpt-4.1-": "o200k_base", # e.g., gpt-4.1-2025-04-14
       "gpt-4o-": "o200k_base",  # e.g., gpt-4o-2024-05-13, etc.
       "gpt-4-": "cl100k_base",  # e.g., gpt-4-0314, etc., plus gpt-4-32k
       "gpt-3.5-turbo-": "cl100k_base",  # e.g, gpt-3.5-turbo-0301, -0401, etc.


### PR DESCRIPTION
Add GPT 4.1 to the ENCODING matrix. It uses the same encoding as gpt4o as per https://community.openai.com/t/whats-the-tokenization-algorithm-gpt-4-1-uses/1245758

tiktoken-rs was [also updated](https://github.com/zurawiki/tiktoken-rs/commit/a6d4930841f19e2399698f1971beae4e597bd9d4#diff-aec14678e2fc5910b09a3a12ecb1c98fcd92667669fbd2d6e269eba20965b9aaR38) with this change recently.