### PR TITLE
Update rb_sys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,4 @@ target/
 # rspec failure tracking
 .rspec_status
 
-vendor/cache
+vendor/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     tiktoken_ruby (0.0.11.1)
-      rb_sys (= 0.9.115)
+      rb_sys (~> 0.9)
 
 GEM
   remote: https://rubygems.org/
@@ -24,7 +24,7 @@ GEM
     rake-compiler (1.3.0)
       rake
     rake-compiler-dock (1.9.1)
-    rb_sys (0.9.115)
+    rb_sys (0.9.117)
       rake-compiler-dock (= 1.9.1)
     regexp_parser (2.10.0)
     rspec (3.13.0)


### PR DESCRIPTION
I was trying to install a new version of a gem that depends on rb_sys which was blocked by tiktoken's current version. 

So an update would be great.