### PR TITLE
Add support for GPT-5 models

### DIFF
--- a/lib/tiktoken_ruby.rb
+++ b/lib/tiktoken_ruby.rb
@@ -133,6 +133,7 @@ module Tiktoken
       "o3-": "o200k_base",
       "o4-": "o200k_base",
       # chat
+      "gpt-5-": "o200k_base",
       "gpt-4.1-": "o200k_base",
       "chatgpt-4o-": "o200k_base",
       "gpt-4o-": "o200k_base",  # e.g., gpt-4o-2024-05-13, etc.


### PR DESCRIPTION
Adds "gpt-5-" prefix mapping to o200k_base encoding to support upcoming GPT-5 models, following the upstream tiktoken Python library implementation.

This change allows the library to properly tokenize text for any GPT-5 model variants (e.g., gpt-5-turbo, gpt-5-preview, etc.) by mapping them to the o200k_base encoding, consistent with the upstream Python tiktoken library.